### PR TITLE
Fix/homedir deprecated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,6 +326,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +446,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "git2"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +503,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossterm",
+ "dirs",
  "git2",
  "gitlab",
  "netrc-rs",
@@ -912,6 +945,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,6 +1035,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitlab-tui"
-version = "0.0.3"
+version = "0.1.0"
 edition = "2021"
 authors = ["Niklas Treml"]
 description = "A terminal based UI for interacting with your gitlab issues and merge requests"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ thiserror = "1.0.40"
 netrc-rs = "0.1.2"
 chrono = "0.4.26"
 clap = { version = "4.3.11", features = ["derive"] }
+dirs = "5.0.1"
 
 
 [[bin]]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -89,9 +89,7 @@ pub enum NetrcError {
 
 // parses .netrc  and tries to find a token for <domain>
 pub fn get_token(domain: String) -> Result<String, Box<dyn Error>> {
-    let home_dir = std::env::home_dir()
-        .ok_or(NetrcError::NotFound)?
-        .join(".netrc");
+    let home_dir = dirs::home_dir().ok_or(NetrcError::NotFound)?.join(".netrc");
     let netrc: String = fs::read_to_string(home_dir)?.parse()?;
 
     let res = netrc_rs::Netrc::parse(netrc, false).or(Err(NetrcError::Invalid))?;


### PR DESCRIPTION
Fixes the deprecation warning for using std::env::home_dir() also bumps version to 0.1.0